### PR TITLE
Fix login user typos in user management tasks

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,7 +1,7 @@
 ---
 # Tasks for configuring MySQL users
 
-- name: Ensure MariaDB users exis
+- name: Ensure MariaDB users exist
   mysql_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
@@ -9,15 +9,15 @@
     priv: "{{ item.priv | default('*.*:USAGE') }}"
     append_privs: "{{ item.append_privs | default(false) }}"
     state: "{{ item.state | default('present') }}"
-    login_user: roo
+    login_user: root
     login_password: "{{ mariadb_root_password }}"
-  with_items: "{{ mariadb_users }}"
+  loop: "{{ mariadb_users }}"
   no_log: true
   tags: [mariadb, users]
 
 - name: Get list of current users
   mysql_query:
-    login_user: roo
+    login_user: root
     login_password: "{{ mariadb_root_password }}"
     query: "SELECT User, Host FROM mysql.user;"
   register: current_mysql_users
@@ -29,10 +29,10 @@
   mysql_user:
     name: "{{ item.User }}"
     host: "{{ item.Host }}"
-    state: absen
-    login_user: roo
+    state: absent
+    login_user: root
     login_password: "{{ mariadb_root_password }}"
-  with_items: "{{ current_mysql_users.query_result }}"
+  loop: "{{ current_mysql_users.query_result }}"
   when:
     - mariadb_remove_unauthorized_users is defined and
       mariadb_remove_unauthorized_users | bool


### PR DESCRIPTION
## Summary
- correct root login username and state in user management tasks
- switch user loops to `loop` for clarity

## Testing
- `yamllint tasks/users.yml`
- `ansible-lint` *(fails: `ansible-config` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895190068c8832785d53acabf336792