### PR TITLE
fix: correct test playbook host and user

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhos
-  remote_user: roo
+- hosts: localhost
+  remote_user: root
+  become: true
   roles:
     - ansible-role-mariadb


### PR DESCRIPTION
## Summary
- fix typo in test playbook host and remote user
- enable privilege escalation in test playbook

## Testing
- `pre-commit run --files tests/test.yml` *(fails: ansible-lint modifies repository files)*

------
https://chatgpt.com/codex/tasks/task_e_68951bb84a8c8327954e46e07a9d7744