### PR TITLE
chore: bump actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -144,7 +144,7 @@ jobs:
     needs: [molecule, supported-distros]
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -186,7 +186,7 @@ jobs:
     needs: docker
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create required directories
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5  # Latest version as of now
+        uses: actions/checkout@v6  # Latest version as of now
         with:
           fetch-depth: 0  # Needed for changelog generation
 


### PR DESCRIPTION
## Summary

This PR updates the `actions/checkout` action from v5 to v6 in all GitHub Actions workflows.

## Changes

- Update `actions/checkout@v5` → `actions/checkout@v6`

## Benefits

- Performance improvements
- Better support for newer GitHub features
- Keeps dependencies up to date
- Security improvements from the latest version

## Testing

The workflows will be automatically tested when this PR is opened. All existing functionality should continue to work as expected since v6 is backward compatible with v5.

## References

- [actions/checkout releases](https://github.com/actions/checkout/releases)
